### PR TITLE
Remove unit tests hitting bug in CentOS python package

### DIFF
--- a/0001-Revert-Add-tests-for-empty-association-set-compariso.patch
+++ b/0001-Revert-Add-tests-for-empty-association-set-compariso.patch
@@ -1,0 +1,51 @@
+From 7da2351a4ad387c4c29a13dcb1001986fdfee829 Mon Sep 17 00:00:00 2001
+From: Alfredo Moralejo <amoralej@redhat.com>
+Date: Tue, 30 Jan 2018 17:44:37 +0000
+Subject: [PATCH] Revert "Add tests for empty association set comparison"
+
+A bug in python version in CentOS makes these tests to fail
+so let's remove then until fixed.
+
+This reverts commit 0612829fb04565c00f8993b978697a8701204977.
+---
+ test/ext/test_associationproxy.py | 26 +-------------------------
+ 1 file changed, 1 insertion(+), 25 deletions(-)
+
+diff --git a/test/ext/test_associationproxy.py b/test/ext/test_associationproxy.py
+index d8fd4dc..408c885 100644
+--- a/test/ext/test_associationproxy.py
++++ b/test/ext/test_associationproxy.py
+@@ -601,30 +601,6 @@ class SetTest(_CollectionOperations):
+             self.assert_((p1.children > other) == (control > other))
+             self.assert_((p1.children >= other) == (control >= other))
+ 
+-    def test_set_comparison_empty_to_empty(self):
+-        # test issue #3265 which appears to be python 2.6 specific
+-        Parent = self.Parent
+-
+-        p1 = Parent('P1')
+-        p1.children = []
+-
+-        p2 = Parent('P2')
+-        p2.children = []
+-
+-        set_0 = set()
+-        set_a = p1.children
+-        set_b = p2.children
+-
+-        is_(set_a == set_a, True)
+-        is_(set_a == set_b, True)
+-        is_(set_a == set_0, True)
+-        is_(set_0 == set_a, True)
+-
+-        is_(set_a != set_a, False)
+-        is_(set_a != set_b, False)
+-        is_(set_a != set_0, False)
+-        is_(set_0 != set_a, False)
+-
+     def test_set_mutation(self):
+         Parent, Child = self.Parent, self.Child
+ 
+-- 
+1.8.3.1
+

--- a/python-sqlalchemy.spec
+++ b/python-sqlalchemy.spec
@@ -6,13 +6,15 @@
 
 Name:           python-sqlalchemy
 Version:        1.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Modular and flexible ORM library for python
 
 Group:          Development/Libraries
 License:        MIT
 URL:            http://www.sqlalchemy.org/
 Source0:        https://files.pythonhosted.org/packages/source/S/%{srcname}/%{srcname}-%{version}.tar.gz
+
+Patch0001:      0001-Revert-Add-tests-for-empty-association-set-compariso.patch
 
 BuildRequires:  python2-devel >= 2.6
 BuildRequires:  python-setuptools
@@ -82,6 +84,7 @@ This package includes the python 3 version of the module.
 
 %prep
 %setup -q -n %{srcname}-%{version}
+%patch1 -p1
 
 %build
 %py2_build
@@ -126,6 +129,9 @@ PYTHONPATH=. "$pytest3" test
 %endif # with_python3
 
 %changelog
+* Tue Jan 30 2018 Alfredo Moralejo <amoralej@redhat.com> - 1.2.2-2
+- Disabled bogus unit tests with python version in CentOS.
+
 * Tue Jan 30 2018 Nils Philippsen <nils@tiptoe.de> - 1.2.2-1
 - version 1.2.2
 


### PR DESCRIPTION
Bug https://bugs.python.org/issue8743 makes these two tests to
fail. The fix is not in python package in CentOS so we need to
disable the tests.

Note that from a functionality perspective, it's safe to ship
sqlcalchemy with this bug in python.